### PR TITLE
Manually update to the latest sdk-k8s version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/networkservicemesh/api v0.0.0-20210609080649-aa4a0cc6c9ea
 	github.com/networkservicemesh/sdk v0.0.0-20210617095054-b99b712833a4
-	github.com/networkservicemesh/sdk-k8s v0.0.0-20210615103705-37e04fde3a93
+	github.com/networkservicemesh/sdk-k8s v0.0.0-20210617095625-2712bb4a2c22
 	github.com/networkservicemesh/sdk-sriov v0.0.0-20210617101024-3107b20fd192
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -248,11 +248,10 @@ github.com/networkservicemesh/api v0.0.0-20210523193133-30a6f075c760/go.mod h1:B
 github.com/networkservicemesh/api v0.0.0-20210609080649-aa4a0cc6c9ea h1:Oz3k/v09FYoXiK7riuotF/vKDxCQBPc+GnwlGmppGds=
 github.com/networkservicemesh/api v0.0.0-20210609080649-aa4a0cc6c9ea/go.mod h1:B6meq/SWjWR6bGXZdXPfbOeaBK+T1JayLdtEJQCsXKU=
 github.com/networkservicemesh/sdk v0.0.0-20210523200103-fb932168d1b8/go.mod h1:5xSpb6F7ZaSC1vsoRjavnR0mvELqr1jArDelVWwjkHE=
-github.com/networkservicemesh/sdk v0.0.0-20210615103202-2d3ff8c3db2a/go.mod h1:6URyucmK3kQQ45Eg7fo57zDtrwIceNx3wBA3OuqN4S8=
 github.com/networkservicemesh/sdk v0.0.0-20210617095054-b99b712833a4 h1:y+Wxvi8J1saQgBgsqodFmQQDXt2/BQfBW2idA8zXPwM=
 github.com/networkservicemesh/sdk v0.0.0-20210617095054-b99b712833a4/go.mod h1:6URyucmK3kQQ45Eg7fo57zDtrwIceNx3wBA3OuqN4S8=
-github.com/networkservicemesh/sdk-k8s v0.0.0-20210615103705-37e04fde3a93 h1:inIqaSMFJvB3j5owx5AfawOi9u4VsLTwquam1Gs/Ya8=
-github.com/networkservicemesh/sdk-k8s v0.0.0-20210615103705-37e04fde3a93/go.mod h1:WPQIAm7T51aoLA/pZvESIOieiUVMRyq2b+79ZhH0B1c=
+github.com/networkservicemesh/sdk-k8s v0.0.0-20210617095625-2712bb4a2c22 h1:LR/91iAYH4XmNSRGPgAOrGpaIhb7sjY8TX2w2ldl+Cw=
+github.com/networkservicemesh/sdk-k8s v0.0.0-20210617095625-2712bb4a2c22/go.mod h1:jZx9Bd1Oyu93GJgfp7mqw1WrPvtR/96i2j/OALVqkrc=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20210523200407-966517b81ae1 h1:V7K7qd3EKIyywz7qm8n2MjU13BjjRQqlX0A0O3a2GpE=
 github.com/networkservicemesh/sdk-kernel v0.0.0-20210523200407-966517b81ae1/go.mod h1:+zP8ld84MAtIiT8zaImN7ayPwjdVX2gg/uaVwFVPWjk=
 github.com/networkservicemesh/sdk-sriov v0.0.0-20210617101024-3107b20fd192 h1:wBqYZwyr17zs2lJikgoPA/9KZF23Bnmubf0Jdc371aU=


### PR DESCRIPTION
Closes https://github.com/networkservicemesh/cmd-forwarder-sriov/pull/200.